### PR TITLE
Add Officers of the Business section

### DIFF
--- a/bylaws.md
+++ b/bylaws.md
@@ -43,14 +43,14 @@
 	- The Secretary shall be responsible for the minutes of the Board, keep all approved minutes in a secure location, and send out copies of minutes to the members.
 
 ## Section 2. Officers of the Business
-1. The Officers of the Business shall consist of a Treasurer and Business Manager, appointed by and serving at the pleasure of the Board.
+1. The Officers of the Business shall consist of a Business Manager and Tresurer, appointed by and serving at the pleasure of the Board.
 2. Any members in good standing can hold a position as an Office of the Business.
-3. Approval shall be accomplished by a majority vote of the Board of Directors during in a board meeting.
-4. Officers may remove themselves from office after providing 30 days of notice to the Board of Directors so that offboarding of responsibilities can be performed.
-5. Officer vacancies will be filled during the next possible board meeting.
-6. Responsibilities
- 	- The Treasurer shall be responsible for general financial oversight, fiscal planning, bookkeeping, financial reporting, and other duties as associated with the position or defined in official policy.
-	- The Business Manager shall be responsible for creating and maintaining business to business relationships for the orginization (including but not limited to: insurance, utilities, other hacker/maker-spaces, conventions/conferences) and other duties as associated with the position or defined in official policy.
+3. Approval shall be accomplished by a majority vote of the Board of Directors.
+4. In the case of a vacancy, an Officer of the Board will assume the responsibility of the role until the vacancy can be filled.
+5. Responsibilities
+	 - The Business Manager shall be responsible for creating and maintaining business to business relationships for the orginization (including but not limited to: insurance, utilities, other hacker/maker-spaces, conventions/conferences) and other duties as associated with the position or defined in official policy.
+	 - The Treasurer shall be responsible for general financial oversight, fiscal planning, bookkeeping, financial reporting, and other duties as associated with the position or defined in official policy.
+
 
 # ARTICLE V. Committees
 1. The Board may appoint standing and ad hoc committees as needed. Committee meetings are managed by the Vice-Chair.

--- a/bylaws.md
+++ b/bylaws.md
@@ -43,12 +43,12 @@
 	- The Secretary shall be responsible for the minutes of the Board, keep all approved minutes in a secure location, and send out copies of minutes to the members.
 
 ## Section 2. Officers of the Business
-1. The Officers of the Business shall consist of a Business Manager and Tresurer, appointed by and serving at the pleasure of the Board.
+1. The Officers of the Business shall consist of a Business Manager and Treasurer, appointed by and serving at the pleasure of the Board.
 2. Any members in good standing can hold a position as an Office of the Business.
 3. Approval shall be accomplished by a majority vote of the Board of Directors.
 4. In the case of a vacancy, an Officer of the Board will assume the responsibility of the role until the vacancy can be filled.
 5. Responsibilities
-	 - The Business Manager shall be responsible for creating and maintaining business to business relationships for the orginization (including but not limited to: insurance, utilities, other hacker/maker-spaces, conventions/conferences) and other duties as associated with the position or defined in official policy.
+	 - The Business Manager shall be responsible for creating and maintaining business-to-business relationships for the organization (including but not limited to insurance, utilities, other hacker/maker spaces, conventions/conferences) and other duties as associated with the position or defined in official policy.
 	 - The Treasurer shall be responsible for general financial oversight, fiscal planning, bookkeeping, financial reporting, and other duties as associated with the position or defined in official policy.
 
 

--- a/bylaws.md
+++ b/bylaws.md
@@ -31,14 +31,25 @@
 5. Board members may lose their board seat by a supermajority vote of the board, but without affecting their current membership status.
 
 # ARTICLE IV. Officers
+
+## Section 1. Officers of the Board
 1. The Officers of the Board shall consist of a Chair, Vice-Chair, and Secretary, nominated by the Board.
-2. Approval shall be accomplished by majority vote of the Board of Directors. 
+2. Approval shall be accomplished by a majority vote of the Board of Directors. 
 3. Officers shall be elected during a special executive session to be held immediately following a regular election.
 4. Elected officers will serve until the next election. Officer vacancies will be filled during the next possible board meeting.
 5. Responsibilities
 	- The Chair shall preside at all Board meetings, appoint committee members, publish the board meeting agendas, and perform other duties as associated with the position.
 	- The Vice-Chair shall assume the duties of the Chair in case of the Chair’s absence or incapacitation. The Vice-Chair shall also preside over committee meetings.
 	- The Secretary shall be responsible for the minutes of the Board, keep all approved minutes in a secure location, and send out copies of minutes to the members.
+
+## Section 2. Officers of the Business
+1. The Officers of the Business shall consist of a Treasurer, appointed by and serving at the pleasure of the Board.
+2. Any members in good standing can hold a position as an Office of the Business.
+3. Approval shall be accomplished by a majority vote of the Board of Directors during in a board meeting.
+4. Officers may remove themselves from office after providing 30 days of notice to the Board of Directors so that offboarding of responsibilities can be performed.
+5. Officer vacancies will be filled during the next possible board meeting.
+6. Responsibilities
+ 	- The Treasurer shall be responsible for general financial oversight, fiscal planning, bookkeeping, financial reporting, and other duties as associated with the position or defined in official policy.
 
 # ARTICLE V. Committees
 1. The Board may appoint standing and ad hoc committees as needed. Committee meetings are managed by the Vice-Chair.

--- a/bylaws.md
+++ b/bylaws.md
@@ -34,8 +34,8 @@
 
 ## Section 1. Officers of the Board
 1. The Officers of the Board shall consist of a Chair, Vice-Chair, and Secretary, nominated by the Board.
-2. Approval shall be accomplished by a majority vote of the Board of Directors. 
-3. Officers shall be elected during a special executive session to be held immediately following a regular election.
+2. Officers shall be elected during a special executive session to be held immediately following a regular election.
+3. Approval shall be accomplished by a majority vote of the Board of Directors.
 4. Elected officers will serve until the next election. Officer vacancies will be filled during the next possible board meeting.
 5. Responsibilities
 	- The Chair shall preside at all Board meetings, appoint committee members, publish the board meeting agendas, and perform other duties as associated with the position.

--- a/bylaws.md
+++ b/bylaws.md
@@ -43,13 +43,14 @@
 	- The Secretary shall be responsible for the minutes of the Board, keep all approved minutes in a secure location, and send out copies of minutes to the members.
 
 ## Section 2. Officers of the Business
-1. The Officers of the Business shall consist of a Treasurer, appointed by and serving at the pleasure of the Board.
+1. The Officers of the Business shall consist of a Treasurer and Business Manager, appointed by and serving at the pleasure of the Board.
 2. Any members in good standing can hold a position as an Office of the Business.
 3. Approval shall be accomplished by a majority vote of the Board of Directors during in a board meeting.
 4. Officers may remove themselves from office after providing 30 days of notice to the Board of Directors so that offboarding of responsibilities can be performed.
 5. Officer vacancies will be filled during the next possible board meeting.
 6. Responsibilities
  	- The Treasurer shall be responsible for general financial oversight, fiscal planning, bookkeeping, financial reporting, and other duties as associated with the position or defined in official policy.
+	- The Business Manager shall be responsible for creating and maintaining business to business relationships for the orginization (including but not limited to: insurance, utilities, other hacker/maker-spaces, conventions/conferences) and other duties as associated with the position or defined in official policy.
 
 # ARTICLE V. Committees
 1. The Board may appoint standing and ad hoc committees as needed. Committee meetings are managed by the Vice-Chair.


### PR DESCRIPTION
# What:
- Added Officers of the Business Section.
- This section defines the process and procedure of adding, removing, and responsibilities of an Officer of the Business.
- This section adds the Treasurer and Business Manager as an Officer of the Business

# Why:
- Some reporting submitted to the State of Colorado is required to be submitted by an officer of the organization as defined by the organization's bylaws. This can be an officer of the Board or an officer of the Business. Today, only the Chair, Vice-Chair, or Secretary can submit these reports but as they are fiscal reports, this should be a task done by the current and future treasurers. This change to our bylaws recognizes the Treasurer as an Officer of the organization and allows them to act on behalf of the organization.
- This change will also prepare us for the future, should we grow to a point of needing executive officers such as CEO, CFO, COO... etc. In most cases, executive officers report to the board similarly to how our managers do today but are recognized through organizational bylaws to act on behalf of the organization.