### PR TITLE
Laser Cutting SIG Charter

### DIFF
--- a/sigs/sig-lasercutting-charter.md
+++ b/sigs/sig-lasercutting-charter.md
@@ -1,8 +1,8 @@
 # Laser Cutting Special Interest Group Charter
 
-_Updated: 2024-06-25_
+_Updated: 2024-07-02_
 
-_Approved: 0000-00-00_
+_Approved: 2024-07-02_
 
 ## Purpose
 The denhac Laser Cutting Special Interest Group (SIG) exists to coordinate and steward the activities in the laser cutting area of denhac. This SIG is responsible for the maintenance, governance, and administration of the laser cutting equipment, resources, and space at denhac. The SIG advocates for the needs of laser cutter users within denhac and seeks to enrich the organization as a whole by providing opportunities for all members to learn and make new things with laser cutters.
@@ -38,11 +38,9 @@ This section is to identify what actions and functions at denhac the SIG should 
 
 ## Roles
 ### SIG Leads
-A group of two or three SIG Co-Leads form the group of SIG Leads for the Laser Cutting SIG. All SIG Leads must themselves be authorized Laser Cutter Trainers.
-
 The description of these roles here is in addition to the description and expectations of SIG Leads contained within the official denhac ["SIGs @ denhac"](https://github.com/Denhac/denhac-official-docs/blob/main/sigs.md) policy.
 
-The SIG Co-Leads MAY choose to designate one SIG Co-Lead as the SIG Captain for the sake of reducing ambiguity. A SIG Captain designation indicates that the individual is responsible by default, or "when-in-doubt", for performing, managing, and delegating SIG leadership tasks. However, all SIG Leads share equal decision-making authority and thus also share equal SIG governance responsibilities and accountability. SIG Leads should aim for consensus decision-making and put decisions to a vote only when disagreements persist.
+All Laser Cutter SIG Leads must themselves be authorized Laser Cutter Trainers. The number of Leads, selection of Leads, term limits of Leads, etc., will be in accordance with the ["SIGs @ denhac"](https://github.com/Denhac/denhac-official-docs/blob/main/sigs.md) organization-wide policy.
 
 ### Positions of Trust
 Laser Cutter Trainers and Laser Cutter Maintainers are roles that require access to privileged infrastructure functions (such as Slack commands) or require access to restricted equipment (such as laser tubes) within denhac. As such, these roles should be considered Positions of Trust.
@@ -64,3 +62,4 @@ The Laser Cutting SIG will meet once per month unless canceled due to no agenda 
 
 ## Budget
 The SIG requests a monthly recurring budget from the Board for common consumables and maintenance items used by the laser cutting area such as: cleaning supplies, q-tips, isopropyl alcohol, distilled water, chain lube, and laser-safe transfer tape.
+

--- a/sigs/sig-lasercutting-charter.md
+++ b/sigs/sig-lasercutting-charter.md
@@ -1,0 +1,66 @@
+# Laser Cutting Special Interest Group Charter
+
+_Updated: 2024-06-25_
+
+_Approved: 0000-00-00_
+
+## Purpose
+The denhac Laser Cutting Special Interest Group (SIG) exists to coordinate and steward the activities in the laser cutting area of denhac. This SIG is responsible for the maintenance, governance, and administration of the laser cutting equipment, resources, and space at denhac. The SIG advocates for the needs of laser cutter users within denhac and seeks to enrich the organization as a whole by providing opportunities for all members to learn and make new things with laser cutters.
+
+## Scope
+This section is to identify what actions and functions at denhac the SIG should and should not have authority over. These items are called In-Scope and Out-Of-Scope respectively. This scope section is a reference for the SIG’s context and is intended to protect the SIG from infinitely growing ownership.
+
+### In-Scope
+ - Performing actions, functions, and responsibilities common to all denhac SIGs as defined by the denhac Board of Directors (the Board) in the ["SIGs @ denhac"](https://github.com/Denhac/denhac-official-docs/blob/main/sigs.md) policy
+ - Collaborating with the Board, denhac safety officers, and facilities management to ensure that the safety requirements of laser cutting are being met, that safety equipment is in good working condition, and that degraded or expired safety equipment is repaired or replaced
+ - Tracking the budget and expenditures of the laser cutting area
+ - Maintaining denhac-owned laser cutters and associated hardware including the computing infrastructure required to operate the laser cutters
+ - Managing resources dedicated for the use of the laser cutters such as weights, calibration tools, rotary accessories, etc
+ - Maintaining documentation associated with the laser cutting area
+ - Maintaining and improving the laser cutting area within denhac
+ - Facilitating events and enrichment activities in the laser cutting area
+ - Responding to and managing the use of donated laser cutting equipment
+ - Responding to and managing the use of member-owned laser cutting equipment on loan to denhac
+ - Defining policies and procedures local to the laser cutting area
+ - Providing input to the Board on organizational policies and procedures that impact the laser cutting area
+ - Defining the knowledge and skills required for members to be authorized as Laser Cutter Users
+ - Teaching training courses regarding safe and effective usage of the laser cutters that allow all interested and permitted members to become authorized Laser Cutter Users
+ - Defining the knowledge and skills required for members to be appointed to Positions of Trust
+ - Communicating with laser cutter users and general denhac members to educate and remind them of their responsibilities to clean and take care of the laser cutting area
+ - Offering project support and collaborating with other SIGs on denhac projects and events that could benefit from laser cutter use
+ - Addressing membership concerns and questions specific to equipment within the laser cutting area
+
+### Out-of-Scope
+ - Maintaining member-owned laser cutting equipment outside of what is explicitly agreed to in equipment loan agreements
+ - Storing or caretaking of member-owned materials
+ - Anything not specifically listed as In-Scope
+ - Individual responsibilities that are the duty of every denhac member, such as those found in the [denhac Membership Agreement](https://github.com/Denhac/denhac-official-docs/blob/main/membership-agreement.md). For example, reporting incidents that happen in the laser cutting area is the responsibility of all denhac members; it is not exclusively the responsibility of members of the Laser Cutting SIG.
+
+## Roles
+### SIG Leads
+A group of two or three SIG Co-Leads form the group of SIG Leads for the Laser Cutting SIG. All SIG Leads must themselves be authorized Laser Cutter Trainers.
+
+The description of these roles here is in addition to the description and expectations of SIG Leads contained within the official denhac ["SIGs @ denhac"](https://github.com/Denhac/denhac-official-docs/blob/main/sigs.md) policy.
+
+The SIG Co-Leads MAY choose to designate one SIG Co-Lead as the SIG Captain for the sake of reducing ambiguity. A SIG Captain designation indicates that the individual is responsible by default, or "when-in-doubt", for performing, managing, and delegating SIG leadership tasks. However, all SIG Leads share equal decision-making authority and thus also share equal SIG governance responsibilities and accountability. SIG Leads should aim for consensus decision-making and put decisions to a vote only when disagreements persist.
+
+### Positions of Trust
+Laser Cutter Trainers and Laser Cutter Maintainers are roles that require access to privileged infrastructure functions (such as Slack commands) or require access to restricted equipment (such as laser tubes) within denhac. As such, these roles should be considered Positions of Trust.
+
+There is not a fixed number of Trainer and Maintainer positions available; they are filled based on demonstrated skill, merit, enthusiasm, and availability.
+
+Laser Cutter Trainers are responsible for training and authorizing denhac members as Laser Cutter Users. Laser Cutter Trainers are also responsible for training and authorizing Laser Cutter Users as new Laser Cutter Trainers. Authorization to be a Laser Cutter Trainer may only be granted by other Trainers or Maintainers.
+
+Laser Cutter Maintainers are responsible for performing maintenance and repairs on the laser cutting machines. Since maintenance and repair of laser cutting machines involves significant risks and safety considerations beyond normal laser cutter use, members can only be appointed as a Laser Cutter Maintainer by vote of SIG Leads or by the Board.
+
+## Organization Management
+The denhac wiki will be used to store the SIG's important safety guides, user guides, and general information. The denhac GitHub will be used to store SIG meeting minutes and official policies and procedures.
+
+Official SIG communication will be conducted through the denhac Slack workspace using public channels for communication with SIG members and denhac members, and private channels for communication among SIG Leads and Positions of Trust. Currently, those channels are:
+ - Public: #sig-laser-cutting, #help-laser-pew-pew
+ - Private: #sigops-laser-cutting
+
+The Laser Cutting SIG will meet once per month unless canceled due to no agenda items for the month. Meeting details and call for agenda items will be organized openly in the public SIG Slack channel and the event details will be posted on the denhac web calendar. 
+
+## Budget
+The SIG requests a monthly recurring budget from the Board for common consumables and maintenance items used by the laser cutting area such as: cleaning supplies, q-tips, isopropyl alcohol, distilled water, chain lube, and laser-safe transfer tape.


### PR DESCRIPTION
Included here is the proposed Laser Cutting Special Interest Group Charter which has been updated to address the comments from the Board. The initial commit is the first version that was sent out via email before the Board meeting, and the current commit is the updated version that changes the Leads section to match what is in the organization-wide "SIGs @ denhac" document.