### PR TITLE
Code of conduct 2024 October revisions

### DIFF
--- a/code-of-conduct-2024-addendum.md
+++ b/code-of-conduct-2024-addendum.md
@@ -22,6 +22,6 @@ Board members should collect the following standard information when receiving a
   * When?
   * Where?
   * How?
-* If there is any action you'd like to request that the board takes in response to this specific incident - let us know here.
+* If there is any action you'd like to request that the board takes in response to this specific incident - let us know here. It may not be possible to take this action exactly as described, but we would like to respect your autonomy as much as we can in resolving this incident.
 * Please share any additional suggestions you have about how to prevent issues like this from happening.
 

--- a/code-of-conduct-2024-addendum.md
+++ b/code-of-conduct-2024-addendum.md
@@ -1,0 +1,27 @@
+# Process notes and drafted changes, for vote in November 2024:
+
+## Changes to new joiner messaging
+
+The following should be read to every new member when they join, in addition to the existing practices and guidelines that appear when a key card is activated:
+
+* No Harassment: This includes, but is not limited to, attention that comes after a request to stop. Our anti-harassment policy is part of our member agreement - please read it.
+* No Bullying: Recognize and respect everyone’s differences. Treat all members with kindness and respect.
+
+
+## New procedure/form for code of conduct incident reporting
+
+Board members should collect the following standard information when receiving an incident report. This may be an online form in the future but isn't being added as one as a part of this proposal.
+
+* Uniquely identifiable name of the reporter (Slack handle or full name)
+* Date/time of report
+* How would you like us to contact you about this concern/incident?
+* Confidentiality: We strive to keep all incidents confidential within the board, and to follow up with you before any follow up actions we take that could risk reidentifying you to a harasser. Is there any additional concern you have, or special handling that you need to request? (e.g. if a board member caused the incident, or if there is a time-sensitive concern)
+* Details of the issue/incident:
+  * Who?
+  * What?
+  * When?
+  * Where?
+  * How?
+* If there is any action you'd like to request that the board takes in response to this specific incident - let us know here.
+* Please share any additional suggestions you have about how to prevent issues like this from happening.
+

--- a/code-of-conduct-best-practices.md
+++ b/code-of-conduct-best-practices.md
@@ -5,7 +5,7 @@
 
 Our code of conduct covers the minimum standards for behavior at denhac, what behavior is unacceptable, and what happens when potentially unacceptable behavior is reported to the board of directors. This official policy document is meant as an additional document covering "best practices". In general, the idea is that denhac members and visitors aren't constantly toeing the line of acceptability and asking the board to adjudicate every interpersonal dispute, but are instead trying to be actively good to one another and avoid getting to the point where disputes become harassment. 
 
-This document lists examples to help guide our community in thinking through how each of us can respond to potential issues, and how we can react when we experience potentially unacceptable behavior, whether directed at ourselves or others. 
+This document lists examples to help guide our community in thinking through how each of us can respond to potential issues, and how we can react when we experience potentially unacceptable behavior, whether directed at ourselves or others. If we all follow the guidelines in this document, it is less likely that anyone will need to use our anti-harassment policies, and more likely that we can succeed in our attempts to be good to one another.
 
 ## The short version
 
@@ -19,7 +19,7 @@ Some guidelines on behavior:
 
 ### Seeking and receiving informed consent in advance
 
-Our code of conduct states that repeated behavior after being told to stop is prohibited (though we do call out touch and romantic/sexual behaviors as especially risky), and for the behaviors in that list where it is possible to receive consent in advance, you need to receive consent first. This is something that can be done in many small ways through all interactions, not just with a predefined list of risky behaviors.
+Our code of conduct states that repeated behavior towards another member after being told to stop is prohibited (though we do call out touch and romantic/sexual behaviors as especially risky), and for the behaviors in that list where it is possible to receive consent in advance, you need to receive consent first. This is something that can be done in many small ways through all interactions, not just with a predefined list of risky behaviors.
 
 Examples in practice: If you want to make a joke about yourself, are you sure there's nobody there who could think it was a harmful comment about them - how would you know? There are many opportunities in a conversation to get a small positive signal that other people feel comfortable, a quick question that allows someone to know if they want to opt out doesn't have to be a large ordeal. 
 

--- a/code-of-conduct-best-practices.md
+++ b/code-of-conduct-best-practices.md
@@ -1,0 +1,42 @@
+# Best practices for interaction at denhac
+
+
+## What does this document aim to do?
+
+Our code of conduct covers the minimum standards for behavior at denhac, what behavior is unacceptable, and what happens when potentially unacceptable behavior is reported to the board of directors. This official policy document is meant as an additional document covering "best practices". In general, the idea is that denhac members and visitors aren't constantly toeing the line of acceptability and asking the board to adjudicate every interpersonal dispute, but are instead trying to be actively good to one another and avoid getting to the point where disputes become harassment. 
+
+This document lists examples to help guide our community in thinking through how each of us can respond to potential issues, and how we can react when we experience potentially unacceptable behavior, whether directed at ourselves or others. 
+
+## The short version
+
+Some guidelines on behavior:
+
+* If you are unsure if something is appropriate behavior, err on the side of caution. Seek and receive informed consent in advance.
+* Each person you interact with can define what is appropriate for them. When a boundary is set it is your responsibility to ensure that your behavior does not have a negative impact. Intent is one input towards determining a negative impact but it is not the only important context.
+* Problems happen when we assume that our way of thinking or behaving is the norm or ok with everyone. Everyone has their own perspective; be mindful and consider the perspectives of the other people present. An uncaught assumption can be particularly harmful to others when we are in a position of power or privilege. 
+
+## The longer version
+
+### Seeking and receiving informed consent in advance
+
+Our code of conduct states that repeated behavior after being told to stop is prohibited (though we do call out touch and romantic/sexual behaviors as especially risky), and for the behaviors in that list where it is possible to receive consent in advance, you need to receive consent first. This is something that can be done in many small ways through all interactions, not just with a predefined list of risky behaviors.
+
+Examples in practice: If you want to make a joke about yourself, are you sure there's nobody there who could think it was a harmful comment about them - how would you know? There are many opportunities in a conversation to get a small positive signal that other people feel comfortable, a quick question that allows someone to know if they want to opt out doesn't have to be a large ordeal. 
+
+### Defining what is appropriate for you and setting boundaries
+
+Boundary setting is the process of communicating specifics about how you do or don't want to be treated. Anyone can set a boundary for themselves that doesn't impact other people in a harmful way. e.g. "I don't want you to tap me on the shoulder to get my attention, please wave from a distance or say my name" is a good boundary to set if the person doesn't want to be tapped on the shoulder. "I don't want you to wear the color red in the woodshop" is another example of a boundary, but it does impact people in a harmful way, so it wouldn't be a good boundary to set within denhac. You don't need the board of directors involved to set a boundary, but if a reasonable boundary is violated once it's set, it can be grounds for board actions around our code of conduct and anti-harassment policy.
+
+Examples in practice: When something bothers you, when do you tell someone directly and unambiguously, and when do you ignore it and hope for the best? When you do something that bothers someone else, how do you know it's bothered them? It's better for everyone involved when you can trust someone will listen to you when you say are hurt - how can you help someone else by listening when they need that? 
+
+### Everyone has their own perspective
+
+denhac's membership is diverse and comes from different backgrounds, histories and experiences. Problems in communication may occur when we assume that everyone shares our viewpoints or ways of thinking. Careless words and actions can affect other people in unintended ways. 
+
+Examples in practice: It can be respectful to check in with the people in a conversation if you realize you may have misread a situation based on their reaction. It's important to approach that conversation with genuine interest and curiosity in their perspective, rather than while trying to make a point yourself. A denhac community where we all care about how other people see the world is a denhac where we can make friends and strengthen our community support network.
+
+### Power and privilege
+
+While denhac is a volunteer-only organization, and there isn't that much opportunity for hierarchical power within the space, we do not exist outside society at large. All of us have experienced power dynamics in the rest of the world, and all of us bring that context with us when we join denhac, and use that to inform how we treat others here.
+
+Examples in practice: Someone might not like to be singled out for something they can't control (for example, an identity). You might not like to be given advice on something you already know about - when you are giving advice, ask first whether the advice is wanted, think first about if it's advice you would give anyone or if you are assuming someone is a newcomer, and especially if it is novice-friendly information consider whether someone else here may have already given this person the advice you're offering or if it needs to be now.

--- a/code-of-conduct-best-practices.md
+++ b/code-of-conduct-best-practices.md
@@ -48,4 +48,6 @@ While denhac operates as a volunteer organization with minimal hierarchy, societ
 
 Questions to ponder: Have you ever had someone assume you were new to something when you were an expert? Or that you knew what you were doing when really you didn't? Have you ever felt singled out by this?
 
-Examples in practice: When attempting to give unsolicited advice, consider if your advice is objectively correct (e.g., safety concern) or if it is your opinion (e.g., how you would carry out a specific task). Be mindful about giving unsolicited advice by first asking if the advice is wanted and by considering if you're the right person or the only person to give this advice.
+Examples in practice:
+* When attempting to give unsolicited advice, consider if your advice is objectively correct (e.g., safety concern) or if it is your opinion (e.g., how you would carry out a specific task). Be mindful about giving unsolicited advice by first asking if the advice is wanted and by considering if you're the right person or the only person to give this advice.
+* If you are in a position that has some power, such as a SIG trainer, be aware of how your actions may be perceived as powerful or as intimidating. Instead of scheduling a last-minute training, could you include more people by scheduling in advance? Think about what times of day are most inclusive for a newcomer or someone less comfortable with the space.

--- a/code-of-conduct-best-practices.md
+++ b/code-of-conduct-best-practices.md
@@ -1,42 +1,51 @@
 # Best practices for interaction at denhac
 
 
-## What does this document aim to do?
+## Purpose
 
-Our code of conduct covers the minimum standards for behavior at denhac, what behavior is unacceptable, and what happens when potentially unacceptable behavior is reported to the board of directors. This official policy document is meant as an additional document covering "best practices". In general, the idea is that denhac members and visitors aren't constantly toeing the line of acceptability and asking the board to adjudicate every interpersonal dispute, but are instead trying to be actively good to one another and avoid getting to the point where disputes become harassment. 
+This document outlines best practices for behavior at denhac, complementing our existing code of conduct. It emphasizes each member's responsibility to assess their intent, action, and impact. The code of conduct establishes minimum standards for acceptable conduct, identifies unacceptable behavior, and describes the procedures for reporting such behavior to the board of directors. denhac's goal is to foster a positive environment where members and visitors engage constructively, minimizing conflicts and preventing harassment.
 
-This document lists examples to help guide our community in thinking through how each of us can respond to potential issues, and how we can react when we experience potentially unacceptable behavior, whether directed at ourselves or others. If we all follow the guidelines in this document, it is less likely that anyone will need to use our anti-harassment policies, and more likely that we can succeed in our attempts to be good to one another.
+## Summary of Guidelines
 
-## The short version
+Err on the Side of Caution: If uncertain about appropriate behavior, seek and receive informed consent in advance.
 
-Some guidelines on behavior:
+Respect Individual Boundaries: Each person communicates their own boundaries. When a reasonable boundary is set, it is your responsibility to adhere to it. While intent matters, it is not the sole factor in assessing an individual's action and impact.
 
-* If you are unsure if something is appropriate behavior, err on the side of caution. Seek and receive informed consent in advance.
-* Each person you interact with can define what is appropriate for them. When a boundary is set it is your responsibility to ensure that your behavior does not have a negative impact. Intent is one input towards determining a negative impact but it is not the only important context.
-* Problems happen when we assume that our way of thinking or behaving is the norm or ok with everyone. Everyone has their own perspective; be mindful and consider the perspectives of the other people present. An uncaught assumption can be particularly harmful to others when we are in a position of power or privilege. 
+Acknowledge Diverse Perspectives: Assumptions about norms can lead to misunderstandings. Be mindful of differing viewpoints, particularly when in a position of leadership, power, and/or privilege.
 
-## The longer version
+## Detailed Guidance
 
 ### Seeking and receiving informed consent in advance
 
-Our code of conduct states that repeated behavior towards another member after being told to stop is prohibited (though we do call out touch and romantic/sexual behaviors as especially risky), and for the behaviors in that list where it is possible to receive consent in advance, you need to receive consent first. This is something that can be done in many small ways through all interactions, not just with a predefined list of risky behaviors.
+For behaviors where consent can be obtained in advance, it is essential to do so beforehand. This applies to all interactions, not just those deemed risky, such as romantic or sexual advances.
 
-Examples in practice: If you want to make a joke about yourself, are you sure there's nobody there who could think it was a harmful comment about them - how would you know? There are many opportunities in a conversation to get a small positive signal that other people feel comfortable, a quick question that allows someone to know if they want to opt out doesn't have to be a large ordeal. 
+Questions to ponder: When you say something about yourself, are you sure there's nobody there who could think it was a harmful comment about them? How would you know? 
+
+Examples in practice: Before making a potentially sensitive joke, consider your audience and whether it may inadvertently harm them or another individual(s) nearby. A simple check-in can facilitate comfort in conversations. A small positive signal that other people feel comfortable, or a quick question that allows someone to know if they want to opt out, doesn't have to be a large ordeal. 
 
 ### Defining what is appropriate for you and setting boundaries
 
-Boundary setting is the process of communicating specifics about how you do or don't want to be treated. Anyone can set a boundary for themselves that doesn't impact other people in a harmful way. e.g. "I don't want you to tap me on the shoulder to get my attention, please wave from a distance or say my name" is a good boundary to set if the person doesn't want to be tapped on the shoulder. "I don't want you to wear the color red in the woodshop" is another example of a boundary, but it does impact people in a harmful way, so it wouldn't be a good boundary to set within denhac. You don't need the board of directors involved to set a boundary, but if a reasonable boundary is violated once it's set, it can be grounds for board actions around our code of conduct and anti-harassment policy.
+Boundary setting is the process of communicating specifics about how you do or don't want to be treated. Anyone can set a boundary for themselves that doesn't impact other people in a harmful way. You don't need the board of directors involved to set a boundary, but if a reasonable boundary is violated, it can be grounds for board actions around our code of conduct and anti-harassment policy.
 
-Examples in practice: When something bothers you, when do you tell someone directly and unambiguously, and when do you ignore it and hope for the best? When you do something that bothers someone else, how do you know it's bothered them? It's better for everyone involved when you can trust someone will listen to you when you say are hurt - how can you help someone else by listening when they need that? 
+Questions to ponder: When something bothers you, when do you tell someone directly and unambiguously, and when do you ignore it and hope for the best? When you do something that bothers someone else, how do you know it's bothered them? 
+
+Examples in practice:
+
+* "I don't want you to tap me on the shoulder to get my attention, please wave from a distance or say my name" is a good boundary to set if the person doesn't want to be tapped on the shoulder. 
+* "I don't want you to wear the color red in the woodshop" is another example of a boundary, but it does impact people in a harmful way, so it is not reasonable to set within denhac.
 
 ### Everyone has their own perspective
 
-denhac's membership is diverse and comes from different backgrounds, histories and experiences. Problems in communication may occur when we assume that everyone shares our viewpoints or ways of thinking. Careless words and actions can affect other people in unintended ways. 
+denhac's membership is diverse, and communication issues can arise from assumptions of shared viewpoints. Careless actions and remarks can have unintended impacts.
 
-Examples in practice: It can be respectful to check in with the people in a conversation if you realize you may have misread a situation based on their reaction. It's important to approach that conversation with genuine interest and curiosity in their perspective, rather than while trying to make a point yourself. A denhac community where we all care about how other people see the world is a denhac where we can make friends and strengthen our community support network.
+Questions to ponder: What viewpoints do you have that you think are commonly held at denhac? What viewpoints do you have that you think you are in the minority at denhac?
 
-### Power and privilege
+Examples in practice: It can be respectful to check in with the people in a conversation if you realize you may have misread a situation based on their reaction. It's important to approach that conversation with genuine interest and curiosity in their perspective, rather than trying to make a point yourself. A denhac community where we all care about how other people see the world is a denhac where we can make friends and strengthen our community support network.
 
-While denhac is a volunteer-only organization, and there isn't that much opportunity for hierarchical power within the space, we do not exist outside society at large. All of us have experienced power dynamics in the rest of the world, and all of us bring that context with us when we join denhac, and use that to inform how we treat others here.
+### Leadership, power and privilege
 
-Examples in practice: Someone might not like to be singled out for something they can't control (for example, an identity). You might not like to be given advice on something you already know about - when you are giving advice, ask first whether the advice is wanted, think first about if it's advice you would give anyone or if you are assuming someone is a newcomer, and especially if it is novice-friendly information consider whether someone else here may have already given this person the advice you're offering or if it needs to be now.
+While denhac operates as a volunteer organization with minimal hierarchy, societal power dynamics still influence interactions. Awareness of these dynamics is crucial.
+
+Questions to ponder: Have you ever had someone assume you were new to something when you were an expert? Or that you knew what you were doing when really you didn't? Have you ever felt singled out by this?
+
+Examples in practice: When attempting to give unsolicited advice, consider if your advice is objectively correct (e.g., safety concern) or if it is your opinion (e.g., how you would carry out a specific task). Be mindful about giving unsolicited advice by first asking if the advice is wanted and by considering if you're the right person or the only person to give this advice.

--- a/code-of-conduct-best-practices.md
+++ b/code-of-conduct-best-practices.md
@@ -3,7 +3,7 @@
 
 ## Purpose
 
-This document outlines best practices for behavior at denhac, complementing our existing code of conduct. It emphasizes each member's responsibility to assess their intent, action, and impact. The code of conduct establishes minimum standards for acceptable conduct, identifies unacceptable behavior, and describes the procedures for reporting such behavior to the board of directors. denhac's goal is to foster a positive environment where members and visitors engage constructively, minimizing conflicts and preventing harassment.
+This document outlines best practices for behavior at denhac, complementing our existing code of conduct. It emphasizes each member's responsibility to assess their intent, action, and impact. The code of conduct establishes minimum standards for acceptable conduct, identifies unacceptable behavior, and describes the procedures for reporting such behavior to the board of directors. denhac's goal is to foster a positive environment where members and visitors engage constructively, minimizing conflicts and preventing harassment. This document does not need board vote for modification and is superseded by the Code of Conduct if the two are in conflict. 
 
 ## Summary of Guidelines
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -15,22 +15,22 @@ denhac does not tolerate harassment of people at our events or space in any form
 Behavior considered as harassment includes, but is not limited to:
 
 1. Offensive comments including epithets, slurs, negative stereotyping, verbal kidding, teasing, jokes, or intimidating acts related to race, religion, gender, gender identity and expression, sexual orientation, disability, or physical appearance. Consider that calling attention to differences can feel alienating.
-2. Gratuitous sexual or obscene objects, images, discussions, or behavior.
-3. Physical contact, romantic advances, or sexual attention that continues after a request to stop or a negative/"no" response.
-4. Physical contact or sexual attention that does not receive informed and voluntary consent in advance.
-5. Subtle or explicit demands for sexual activity.
-6. Verbal abuse.
+2. Gratuitous sexual or obscene objects, images, discussions, or behavior
+3. Physical contact, romantic advances, sexual attention, or other contact or messaging that continues after a request to stop or a negative/"no" response
+4. Physical contact, sexual or romantic attention, or other actions where informed and voluntary consent can be expected to be received, but was not received in advance
+5. Subtle or explicit demands for sexual or romantic activity
+6. Physical or verbal abuse
 7. Threats or incitement of violence towards any individual, including encouraging a person to engage in self-harm
 8. Deliberate intimidation by words, gestures, body language, or menacing behavior
 9. Stalking
 10. Harassing photography or recording, including logging online activity for harassment purposes
-11. Continued one-on-one contact or communication after requests to cease
+11. Continued one-on-one contact or communication after active requests to cease, multiple instances of no response, or other indicators of a lack of consent
 12. Deliberate outing/sharing of a sensitive aspect of a person’s identity without their consent
-13. Deliberate misgendering. This includes dead-naming or persistently using a pronoun that does not correctly reflect a person’s gender identity
+13. Deliberate misgendering. This includes dead-naming or persistently using a pronoun that does not correctly reflect a person’s gender identity.
 14. Retaliating against anyone who files a complaint that someone has violated this code of conduct 
 
 # How to submit a harassment report
-Reports should be submitted in writing on Slack or via denhac.org email to any member of our Board of Directors, listed at https://denhac.org/wiki/the-board; the entire board is also available via email at board@denhac.org. If your report is given to a single member of the board, they will ask to pull in a second board member of your choice, to share the detailed context of the issue in order to better represent it to the rest of the board and help address the issue.
+Reports should be submitted in writing (e.g. on Slack or via denhac.org email) to any member of our Board of Directors, listed at https://denhac.org/wiki/the-board; the entire board is also available via email at board@denhac.org. If your report is given to a single member of the board, they will ask to pull in a second board member of your choice, to share the detailed context of the issue in order to better represent it to the rest of the board and help address the issue.
 
 # What happens when a harassment report is submitted
 Report information will be shared and discussed privately over board-only slack and/or private board executive session - current board members are the only ones present at the time of discussion, but future board members may have access to the discussion log as well. Board members will investigate the report privately (potentially including use of our camera footage but we will check in with the reporter before taking any actions which might reidentify the reporter to a harasser), discuss and decide on next steps to address the incident, and communicate back to the reporter on the next steps chosen within a week after the next Executive Session completes. Anonymous summaries of public events that require a statement, and/or summary statistics around incident management, may also be shared more widely across denhac for transparency.
@@ -41,9 +41,9 @@ denhac reserves the right to terminate any membership at any time for any reason
 * The member will get a verbal warning from a Director or a Manager.
 * The member will be called before the Board to explain and/or discuss the behavior in question, usually within Executive Session.
 * The member will receive a formal Warning, via letter or email, signed by a board member.
-* The Member will be put on probation.
-* Membership will be suspended for a length of time.
-* Membership will be terminated.
+* The member will be put on probation and removed from good standing.
+* Membership will be suspended for a predefined length of time, often until the next public board meeting. This can be done by any one board member or manager if there is a safety concern.
+* Membership will be terminated indefinitely, often called a "ban". This can usually only be done by public board vote.
 
 Note that some offenses – such as non-payment of dues, or negligence leading to danger to our members or physical space – can trigger automatic membership suspension or termination, without a formal review by the Board.
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -24,7 +24,7 @@ Behavior considered as harassment includes, but is not limited to:
 8. Deliberate intimidation by words, gestures, body language, or menacing behavior
 9. Stalking
 10. Harassing photography or recording, including logging online activity for harassment purposes
-11. Continued one-on-one contact or communication after active requests to cease, multiple instances of no response, or other indicators of a lack of consent
+11. Continued one-on-one contact or communication after active requests to cease or other indicators of a lack of consent (such as a pattern of sending multiple long messages that are not necessary to space operations and that receive no response)
 12. Deliberate outing/sharing of a sensitive aspect of a person’s identity without their consent
 13. Deliberate misgendering. This includes dead-naming or persistently using a pronoun that does not correctly reflect a person’s gender identity.
 14. Retaliating against anyone who files a complaint that someone has violated this code of conduct 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -2,9 +2,9 @@
 
 denhac does not promote or discriminate against any person, population group, or organization with regard to categories protected by applicable United States law. These include, but are not limited to race, color, religion, sex, gender expression, sexuality, physical appearance, language, education background, national origin, age, disability, and veteran status.
 
-denhac strives to create an inclusive environment where everyone can feel welcome and respected in our space. While there is not a formal hierarchy here as in a workplace, everyone comes into our space with their own different histories and social norms. We on the Board of Directors expect you to both communicate with each other about the boundaries/limits you wish to hold, and respect when someone else communicates a boundary with you. If a boundary is clearly expressed to you (whether in person, over Slack messages, or via other means), and you deliberately overstep that boundary, it will be treated as a violation of our anti-harassment policy. Initial communication of a boundary can be done without direct board member support in most cases, but please reach out to any member of the Board of Directors if you would like support of any kind in any phase of the process of boundary setting. 
+denhac strives to create an inclusive environment where everyone can feel welcome and respected in our space. While there is not a formal hierarchy here as in a workplace, everyone comes into our space with their own different histories and social norms. We on the Board of Directors expect members to both communicate with each other about the boundaries/limits you each wish to hold, and respect when someone else communicates a boundary with you. If a member deliberately oversteps a boundary that is clearly expressed to them (whether in person, over Slack messages, or via other means) it will be treated as a violation of our anti-harassment policy and the board may need to take disciplinary action, if relevant. Initial communication of a boundary can be done without direct board member support in most cases, but please reach out to any member of the Board of Directors if you would like support of any kind in any phase of the process of boundary setting.
 
-If you feel that you have been harassed at denhac or if someone has made you uncomfortable (even if you aren’t sure if it’s harassment), we on the Board of Directors encourage you to follow the reporting procedure in our code of conduct. Everyone can help make denhac better, and creating a safe environment for you is important to making denhac better. Board members can’t act to officially address potential issues if we aren’t made aware of them.
+If you feel that you have been harassed at denhac or if someone has made you uncomfortable (even if you aren’t sure if it’s harassment), we on the Board of Directors encourage you to follow the reporting procedure in our code of conduct. Everyone can help make denhac better, and creating a safe environment for everyone is important to making denhac better. Board members can’t act to officially address potential issues if we aren’t made aware of them.
 
 # Code of conduct and anti-harassment policy
 
@@ -41,10 +41,11 @@ denhac reserves the right to terminate any membership at any time for any reason
 * The member will get a verbal warning from a Director or a Manager.
 * The member will be called before the Board to explain and/or discuss the behavior in question, usually within Executive Session.
 * The member will receive a formal Warning, via letter or email, signed by a board member.
-* The member will be put on probation and removed from good standing.
-* Membership will be suspended for a predefined length of time, often until the next public board meeting. This can be done by any one board member or manager if there is a safety concern.
-* Membership will be terminated indefinitely, often called a "ban". This can usually only be done by public board vote.
+* The member will be put on probation.
+* Membership will be suspended for a length of time.
+* Membership will be terminated.
 
 Note that some offenses – such as non-payment of dues, or negligence leading to danger to our members or physical space – can trigger automatic membership suspension or termination, without a formal review by the Board.
+Definitions of suspension and termination can be found in our [membership agreements](https://github.com/Denhac/denhac-official-docs/blob/main/membership-agreement.md).
 
 *Thank you to Geek Feminism Wiki for their [detailed code of conduct documentation](https://geekfeminism.fandom.com/wiki/Code_of_conduct_evaluations).*

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -2,18 +2,17 @@
 
 denhac does not promote or discriminate against any person, population group, or organization with regard to categories protected by applicable United States law. These include, but are not limited to race, color, religion, sex, gender expression, sexuality, physical appearance, language, education background, national origin, age, disability, and veteran status.
 
-denhac strives to create an inclusive environment where everyone can feel welcome and respected in our space. We know that, while there is not a formal hierarchy here as in a workplace, everyone comes into our space with their own different histories and social norms. We expect you to both communicate with each other about the boundaries/limits you wish to hold, and respect when someone else communicates a boundary with you. If a boundary is clearly expressed to you (whether in person, over Slack messages, or via other means), and you deliberately overstep that boundary, it will be treated as a violation of our anti-harassment policy. We believe that initial communication of a boundary can be done without board support in most cases, but please reach out to any member of the Board of Directors if you would like support of any kind in any phase of the process of boundary setting. 
+denhac strives to create an inclusive environment where everyone can feel welcome and respected in our space. While there is not a formal hierarchy here as in a workplace, everyone comes into our space with their own different histories and social norms. We on the Board of Directors expect you to both communicate with each other about the boundaries/limits you wish to hold, and respect when someone else communicates a boundary with you. If a boundary is clearly expressed to you (whether in person, over Slack messages, or via other means), and you deliberately overstep that boundary, it will be treated as a violation of our anti-harassment policy. Initial communication of a boundary can be done without direct board member support in most cases, but please reach out to any member of the Board of Directors if you would like support of any kind in any phase of the process of boundary setting. 
 
-If you feel that you have been harassed at denhac or if someone has made you uncomfortable (even if you aren’t sure if it’s harassment), we encourage you to follow the reporting procedure in our code of conduct. We want to make the space better and creating a safe environment for you is important to making denhac better - but we can’t act to address potential issues if we aren’t made aware of them.
+If you feel that you have been harassed at denhac or if someone has made you uncomfortable (even if you aren’t sure if it’s harassment), we on the Board of Directors encourage you to follow the reporting procedure in our code of conduct. Everyone can help make denhac better, and creating a safe environment for you is important to making denhac better. Board members can’t act to officially address potential issues if we aren’t made aware of them.
 
 # Code of conduct and anti-harassment policy
 
-We expect everyone involved in our community to follow this code of conduct. This applies to all of our methods of communication.
+We, the denhac Board of Directors, expect everyone involved in our community to follow this code of conduct. This applies to all of our methods of communication.
 
-We do not tolerate harassment of people at our events or space in any form. 
+denhac does not tolerate harassment of people at our events or space in any form. 
 
-
-We do not seek to list all cases of unacceptable behavior, but provide examples to help guide our community in thinking through how to respond when we experience these types of behavior, whether directed at ourselves or others. 
+This document does not seek to list all cases of unacceptable behavior, but provides examples to help guide our community in thinking through how each of us can respond when we experience these types of behavior, whether directed at ourselves or others. 
 
 Some guidelines on appropriate behavior:
 
@@ -41,13 +40,13 @@ Behavior considered as harassment includes, but is not limited to:
 14. Retaliating against anyone who files a complaint that someone has violated this code of conduct 
 
 # How to submit a harassment report
-Reports should be submitted in writing on Slack or via denhac.org email to any member of our Board of Directors, listed at https://denhac.org/wiki/the-board; the entire board is also available via email at board@denhac.org. If your report is given to a single member of the Board, they will ask to pull in a second board member of your choice, to share the detailed context of the issue in order to better represent it to the rest of the board and help address the issue.
+Reports should be submitted in writing on Slack or via denhac.org email to any member of our Board of Directors, listed at https://denhac.org/wiki/the-board; the entire board is also available via email at board@denhac.org. If your report is given to a single member of the board, they will ask to pull in a second board member of your choice, to share the detailed context of the issue in order to better represent it to the rest of the board and help address the issue.
 
 # What happens when a harassment report is submitted
 Report information will be shared and discussed privately over board-only slack and/or private board executive session - current board members are the only ones present at the time of discussion, but future board members may have access to the discussion log as well. Board members will investigate the report privately (potentially including use of our camera footage but we will check in with the reporter before taking any actions which might reidentify the reporter to a harasser), discuss and decide on next steps to address the incident, and communicate back to the reporter on the next steps chosen within a week after the next Executive Session completes. Anonymous summaries of public events that require a statement, and/or summary statistics around incident management, may also be shared more widely across denhac for transparency.
 
 # Potential consequences of violating the code of conduct
-denhac reserves the right to terminate any membership at any time for any reason, but we strive for the process to be as fair and open as privacy and discretion allow us to be. Upon breaching of the denhac rules and member agreements, the following actions may be performed in any order:
+denhac reserves the right to terminate any membership at any time for any reason, but the Board of Directors strives for the process to be as fair and open as privacy and discretion allow us to be. Upon breaching of the denhac rules and member agreements, the following actions may be performed in any order:
 
 * The member will get a verbal warning from a Director or a Manager.
 * The member will be called before the Board to explain and/or discuss the behavior in question, usually within Executive Session.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -12,21 +12,33 @@ We expect everyone involved in our community to follow this code of conduct. Thi
 
 We do not tolerate harassment of people at our events or space in any form. 
 
+
+We do not seek to list all cases of unacceptable behavior, but provide examples to help guide our community in thinking through how to respond when we experience these types of behavior, whether directed at ourselves or others. 
+
+Some guidelines on appropriate behavior:
+
+* If you are unsure if something is appropriate behavior, err on the side of caution. 
+* Each person you interact with can define what is appropriate for them. 
+* Impact matters more than intent. 
+* It is your responsibility to ensure that your behavior does not have a negative impact.
+* Problems happen when we assume that our way of thinking or behaving is the norm or ok with everyone. This is particularly problematic when we are in a position of power or privilege.
+
 Behavior considered as harassment includes, but is not limited to:
 
 1. Offensive comments including epithets, slurs, negative stereotyping, verbal kidding, teasing, jokes, or intimidating acts related to race, religion, gender, gender identity and expression, sexual orientation, disability, or physical appearance. Consider that calling attention to differences can feel alienating.
 2. Gratuitous sexual or obscene objects, images, discussions, or behavior.
-3. Physical contact, romantic advances, or sexual attention that continues after a request to stop or "no" response.
-4. Subtle or explicit demands for sexual activity.
-5. Verbal abuse.
-6. Threats or incitement of violence towards any individual, including encouraging a person to engage in self-harm
-7. Deliberate intimidation by words, gestures, body language, or menacing behavior
-8. Stalking
-9. Harassing photography or recording, including logging online activity for harassment purposes
-10. Continued one-on-one contact or communication after requests to cease
-11. Deliberate “outing” of a sensitive aspect of a person’s identity without their consent
-12. Deliberate misgendering. This includes dead-naming or persistently using a pronoun that does not correctly reflect a person’s gender identity
-13. Retaliating against anyone who files a complaint that someone has violated this code of conduct 
+3. Physical contact, romantic advances, or sexual attention that continues after a request to stop or a negative/"no" response.
+4. Physical contact or sexual attention that does not receive informed and voluntary consent in advance.
+5. Subtle or explicit demands for sexual activity.
+6. Verbal abuse.
+7. Threats or incitement of violence towards any individual, including encouraging a person to engage in self-harm
+8. Deliberate intimidation by words, gestures, body language, or menacing behavior
+9. Stalking
+10. Harassing photography or recording, including logging online activity for harassment purposes
+11. Continued one-on-one contact or communication after requests to cease
+12. Deliberate outing/sharing of a sensitive aspect of a person’s identity without their consent
+13. Deliberate misgendering. This includes dead-naming or persistently using a pronoun that does not correctly reflect a person’s gender identity
+14. Retaliating against anyone who files a complaint that someone has violated this code of conduct 
 
 # How to submit a harassment report
 Reports should be submitted in writing on Slack or via denhac.org email to any member of our Board of Directors, listed at https://denhac.org/wiki/the-board; the entire board is also available via email at board@denhac.org. If your report is given to a single member of the Board, they will ask to pull in a second board member of your choice, to share the detailed context of the issue in order to better represent it to the rest of the board and help address the issue.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -12,16 +12,6 @@ We, the denhac Board of Directors, expect everyone involved in our community to 
 
 denhac does not tolerate harassment of people at our events or space in any form. 
 
-This document does not seek to list all cases of unacceptable behavior, but provides examples to help guide our community in thinking through how each of us can respond when we experience these types of behavior, whether directed at ourselves or others. 
-
-Some guidelines on appropriate behavior:
-
-* If you are unsure if something is appropriate behavior, err on the side of caution. 
-* Each person you interact with can define what is appropriate for them. 
-* Impact matters more than intent. 
-* It is your responsibility to ensure that your behavior does not have a negative impact.
-* Problems happen when we assume that our way of thinking or behaving is the norm or ok with everyone. This is particularly problematic when we are in a position of power or privilege.
-
 Behavior considered as harassment includes, but is not limited to:
 
 1. Offensive comments including epithets, slurs, negative stereotyping, verbal kidding, teasing, jokes, or intimidating acts related to race, religion, gender, gender identity and expression, sexual orientation, disability, or physical appearance. Consider that calling attention to differences can feel alienating.


### PR DESCRIPTION
The following dates in my September draft are still relevant: 

2024-09-13 (Friday): “October policy text” has a denhac-wide location open to comments, and all content moderation issues have found a viable resolution 
2024-10-01 (Tuesday): October board meeting, public discussion and feedback can be given
2024-10-15 (Tuesday), or one month after the comments open if target is not met: October doc closes to new comments but existing ones may still be in progress
2024-10-29 (Tuesday): October document is final, all comments have been resolved
2024-11-05 (Tuesday): November board meeting discussion, and decision to vote or withdraw on that section 

Additions and changes can still continue in the future as there is desire or need
