### PR TITLE
Add the SIG Electronics charter. This document was approved in the Nov 2024 board mtg

### DIFF
--- a/sigs/sig-electronics-charter.md
+++ b/sigs/sig-electronics-charter.md
@@ -1,0 +1,53 @@
+ Electronics Special Interest Group Charter
+
+_Updated: 2024-11-02_
+
+_Approved: 2024-11-05_
+
+## Purpose
+The denhac Electronics Special Interest Group (SIG) exists to coordinate and steward the activities in the electronics area of denhac. This SIG is responsible for the maintenance, governance, and administration of the electronics equipment, resources, and space at denhac. The SIG advocates for the needs of eletronics enthusiasts within denhac and seeks to enrich the organization as a whole by providing opportunities for all members to learn and make new things with electronics.
+
+## Scope
+This section is to identify what actions and functions at denhac the SIG should and should not have authority over. These items are called In-Scope and Out-Of-Scope respectively. This scope section is a reference for the SIG’s context and is intended to protect the SIG from infinitely growing ownership.
+
+### In-Scope
+ - Performing actions, functions, and responsibilities common to all denhac SIGs as defined by the denhac Board of Directors (the Board) in the ["SIGs @ denhac"](https://github.com/Denhac/denhac-official-docs/blob/main/sigs.md) policy
+ - Collaborating with the Board, denhac safety officers, and facilities management to ensure that the safety requirements of electronics are being met, that safety equipment is in good working condition, and that degraded or expired safety equipment is repaired or replaced
+ - Tracking the budget and expenditures of the electronics area
+ - Maintaining denhac-owned electronics equipment, such as soldering irons, multimeters, oscilloscopes, etc
+ - Managing resources dedicated for the use of electronics equipment such as soldering tips, calibration tools, etc
+ - Maintaining documentation associated with the electronics area
+ - Maintaining and improving the electronics area within denhac
+ - Facilitating events and enrichment activities related to electronics within denhac
+ - Responding to and managing the use of donated electronics equipment
+ - Defining policies and procedures local to the electronics area
+ - Providing input to the Board on organizational policies and procedures that impact the electronics area
+ - Defining the knowledge and skills required for members to be authorized on electronics equipment
+ - Teaching training courses regarding safe and effective usage of electronics equipment
+ - Defining the knowledge and skills required for members to be appointed to Positions of Trust
+ - Communicating with users of the electronics area and general denhac members to educate and remind them of their responsibilities to clean and take care of the electronics area
+ - Offering project support and collaborating with other SIGs on denhac projects and events that could benefit from use of the electronics area
+ - Addressing membership concerns and questions specific to equipment within the electronics area
+
+### Out-of-Scope
+ - Storing or caretaking of member-owned materials
+ - Anything not specifically listed as In-Scope
+ - Individual responsibilities that are the duty of every denhac member, such as those found in the [denhac Membership Agreement](https://github.com/Denhac/denhac-official-docs/blob/main/membership-agreement.md). For example, reporting incidents that happen in the electronics area is the responsibility of all denhac members; it is not exclusively the responsibility of members of the Electronics SIG.
+
+## Roles
+### SIG Leads
+The description of these roles here is in addition to the description and expectations of SIG Leads contained within the official denhac ["SIGs @ denhac"](https://github.com/Denhac/denhac-official-docs/blob/main/sigs.md) policy.
+
+The number of Leads, selection of Leads, term limits of Leads, etc., will be in accordance with the ["SIGs @ denhac"](https://github.com/Denhac/denhac-official-docs/blob/main/sigs.md) organization-wide policy.
+
+## Organization Management
+The denhac wiki will be used to store the SIG's important safety guides, user guides, and general information. The denhac GitHub will be used to store SIG meeting minutes and official policies and procedures.
+
+Official SIG communication will be conducted through the denhac Slack workspace using public channels for communication with SIG members and denhac members, and private channels for communication among SIG Leads. Currently, those channels are:
+ - Public: `#sig-electronics`, `#help-electronics`
+ - Private: `#sigops-electronics`
+
+The Electronics SIG will meet once per month unless canceled due to no agenda items for the month. Meeting details and call for agenda items will be organized openly in the public SIG Slack channel and the event details will be posted on the denhac web calendar.
+
+## Budget
+The SIG requests a monthly recurring budget from the Board for common consumables and maintenance items used by the electronics area such as: cleaning supplies, ipa, solder, flux, wire, and tape.


### PR DESCRIPTION
Doc was worked on by the team in person and on slack in `#sig-electronics`. [Nov 2024 board meeting for ref](https://denhac.org/board-minutes/board-minutes-2024-11-05)